### PR TITLE
Remove requirement for ENG_LIBRARY in find_package(Matlab)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(mujoco-simulink-blockset)
 
-find_package(Matlab REQUIRED COMPONENTS ENG_LIBRARY SIMULINK)
+find_package(Matlab REQUIRED COMPONENTS SIMULINK)
 
 # Create and install mex files
 function(mjb_build_and_install_mex mexname)


### PR DESCRIPTION
In the robotology-superbuild CI, the build is failing with:
~~~
2023-06-20T22:15:38.8741170Z -- Found OpenGL: /Applications/Xcode_14.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenGL.framework   
2023-06-20T22:15:38.8841700Z CMake Error at /Users/runner/miniconda3/envs/test/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
2023-06-20T22:15:38.8941800Z   Could NOT find Matlab (missing: ENG_LIBRARY) (found version "9.8")
2023-06-20T22:15:38.9043290Z Call Stack (most recent call first):
2023-06-20T22:15:38.9143820Z   /Users/runner/miniconda3/envs/test/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
2023-06-20T22:15:38.9244500Z   /Users/runner/miniconda3/envs/test/share/cmake-3.26/Modules/FindMatlab.cmake:2024 (find_package_handle_standard_args)
2023-06-20T22:15:38.9344450Z   CMakeLists.txt:62 (find_package)
~~~